### PR TITLE
Add FIWARE Meteoroid

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ The FIWARE Catalogue holds the list of official curated contributions to the FIW
 - [Waste4think NGSI Connector API](http://dev.waste4think.eu/waste4think/NgsiConnector) - This tool is a part of backend implementation of NGSI v2 standard, providing interface for large entities operations coming from various sources such
   as files, legacy systems etc.
 - [FIWARE Node-Red](https://github.com/FIWARE/node-red-contrib-FIWARE_official) - An integration of [Node-Red](https://nodered.org/) with FIWARE which supports NGSI-LD.
+- [FIWARE Meteoroid](https://github.com/OkinawaOpenLaboratory/fiware-meteoroid) - Meteoroid realizes integrating Function as a Service(FaaS) capabilities in FIWARE.
 
 ### Security
 


### PR DESCRIPTION
We have released a component called "[Meteoroid](https://github.com/OkinawaOpenLaboratory/fiware-meteoroid)".
[Meteoroid](https://github.com/OkinawaOpenLaboratory/fiware-meteoroid) realizes integrating Function as a Service(FaaS) capabilities in FIWARE.
Please add [Meteoroid](https://github.com/OkinawaOpenLaboratory/fiware-meteoroid) to awesome.

[News Release(English)](https://f9ff27d3-56bc-45b3-a7fa-f5a4062c9e50.filesusr.com/ugd/83bf7d_35e54f424f49456b8ce2baea0406b342.pdf)
[Okinawa Open Laboratory Updates](https://www.okinawaopenlabs.org/en#comp-j2joi96v)
[Meteoroid Docs](https://fiware-meteoroid.readthedocs.io/en/latest/)