### PR TITLE
Add 'AMQP1.0 converter' which bridges between AMQP1.0 Broker and IoTAgent JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ The FIWARE Catalogue holds the list of official curated contributions to the FIW
   as files, legacy systems etc.
 - [FIWARE Node-Red](https://github.com/FIWARE/node-red-contrib-FIWARE_official) - An integration of [Node-Red](https://nodered.org/) with FIWARE which supports NGSI-LD.
 - [FIWARE Meteoroid](https://github.com/OkinawaOpenLaboratory/fiware-meteoroid) - Meteoroid realizes integrating Function as a Service(FaaS) capabilities in FIWARE.
+- [AMQP 1.0 converter](https://github.com/RoboticBase/amqp10-converter) - A protocol converter which bridges between AMQP 1.0 Broker and FIWARE IoTAgent JSON.
 
 ### Security
 


### PR DESCRIPTION
We have developed a component called "amqp10-converter" which bridges between AMQP 1.0 Broker and IoTAgent JSON.
By using this component, IoTAgent JSON can connect to Cloud-Managed MessageQueue Service such as [Microsoft Azure ServiceBus](https://azure.microsoft.com/en-us/services/service-bus/) and [AWS Amazon MQ](https://aws.amazon.com/amazon-mq/).

Please add this component to awesome if you think it's good.