### PR TITLE
ADD Node-RED implementation for NGSI

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,8 @@ The FIWARE Catalogue holds the list of official curated contributions to the FIW
 - [FIWARE Orion with Cygnus on AWS](https://github.com/aws-samples/fiware-orion-on-aws) - An implementation for FIWARE Orion and Cygnus on AWS.
 - [Grafana Icon Stat Panel](https://grafana.com/grafana/plugins/orchestracities-iconstat-panel/) - Plugin for QuantumLeap/Grafana which adds icons support to Grafana Stats panel.
 - [Grafana Map Panel](https://grafana.com/grafana/plugins/orchestracities-map-panel/) - Plugin for QuantumLeap/Grafana adds GeoJSON support, icons, popup support and multilayer visualizations to the Grafana Geomap panel.
-
+- [node-red-contrib-letsfiware-NGSI](https://github.com/lets-fiware/node-red-contrib-letsfiware-NGSI) - Node-RED implementation for NGSI-v2.
+- [node-red-contrib-NGSI-LD](https://github.com/lets-fiware/node-red-contrib-NGSI-LD) - Node-RED implementation for NGSI-LD.
 
 ### Security
 


### PR DESCRIPTION
This PR adds a link to the source code repository of  node-red-contrib-letsfiware-NGSI and node-red-contrib-NGSI-LD.
Thanks.